### PR TITLE
Add supported node versions to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
+  - 0.12 # to be removed 2016-12-31
+  - 4 # to be removed 2018-04-01
+  - 6 # to be removed 2019-04-01
+  - lts/* # safety net; don't remove
+  - node # safety net; don't remove
 script:
   - make ci

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "readme": "jsmd README.md",
     "coverage": "istanbul cover _hydro"
   },
+  "engines": {
+    "node": ">=0.12"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/loupe"


### PR DESCRIPTION
Hello there!

I was taking a look at #9 and I found that build was failing there because loupe tells travis to build over node 0.8 which is not supported from `jsmd` anymore. (IMHO, it should not be supported from anyone 😸).

So this PR adds all supported node versions to `.travis.yml`, totally stolen from [chai's](https://github.com/chaijs/chai/blob/9e16c8f1ee42b38688ce3a882ae812d3195b8984/.travis.yml)

Thank you all!