### PR TITLE
fix semantic release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,6 +117,7 @@ jobs:
 
   release:
     name: Publish a Release
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs: [lint, test-node, test-linux-browsers]
     steps:
@@ -136,7 +137,7 @@ jobs:
     - name: Install dependencies
       run: npm i
     - name: Run Semantic Release
-      run: npm run semantic-release
+      run: npx semantic-release
       env:
        NPM_TOKEN: ${{secrets.NPM_TOKEN}}
        GITHUB_TOKEN: ${{secrets.github_token}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,6 @@ jobs:
   release:
     name: Publish a Release
     runs-on: ubuntu-latest
-    if: github.event == 'push'
     needs: [lint, test-node, test-linux-browsers]
     steps:
     - name: Checkout the project


### PR DESCRIPTION
Semantic release is broken because it uses `event` not `event_name`, and also uses the old `semantic-release pre`/`post` steps.