### PR TITLE
fix: dont emit test files for published package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     "type": "git",
     "url": "https://github.com/chaijs/loupe"
   },
+  "files": [
+    "loupe.js",
+    "index.js",
+    "lib/*"
+  ],
   "scripts": {
     "bench": "node -r esm bench",
     "commit-msg": "commitlint -x angular",


### PR DESCRIPTION
This uses the `files` array to avoid publishing all the test files, bench files, rollup config, karma config, Makefile, etc.