### PR TITLE
Fix empty Symbol incorrect return

### DIFF
--- a/lib/symbol.js
+++ b/lib/symbol.js
@@ -1,6 +1,6 @@
 export default function inspectSymbol(value) {
   if ('description' in Symbol.prototype) {
-    return `Symbol(${value.description})`
+    return value.description ? `Symbol(${value.description})` : "'Symbol()'"
   }
   return value.toString()
 }

--- a/test/symbols.js
+++ b/test/symbols.js
@@ -1,6 +1,11 @@
 import inspect from '../index'
 import { expect } from 'chai'
 describe('symbols', () => {
+  /* eslint-disable */
+  it('returns Symbol() for empty Symbol', () => {
+    expect(inspect(Symbol())).to.equal("'Symbol()'")
+  })
+
   it('returns string wrapped in quotes', () => {
     expect(inspect('abc')).to.equal("'abc'")
   })


### PR DESCRIPTION
inspect(Symbol()) was returning incorrect value, due to:
```js
Symbol().description;        // undefined
```