### PR TITLE
fix: ensure custominspect works for plain objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,6 +126,12 @@ export function inspect(value, options) {
     return baseTypesMap[type](value, options)
   }
 
+  // If `options.customInspect` is set to true then try to use the custom inspector
+  if (customInspect && value) {
+    const output = inspectCustom(value, options, type)
+    if (output) return output
+  }
+
   const proto = value ? Object.getPrototypeOf(value) : false
   // If it's a plain Object then use Loupe's inspector
   if (proto === Object.prototype || proto === null) {
@@ -136,12 +142,6 @@ export function inspect(value, options) {
   // eslint-disable-next-line no-undef
   if (value && typeof HTMLElement === 'function' && value instanceof HTMLElement) {
     return inspectHTMLElement(value, options)
-  }
-
-  // If `options.customInspect` is set to true then try to use the custom inspector
-  if (customInspect && value) {
-    const output = inspectCustom(value, options, type)
-    if (output) return output
   }
 
   // If it is a class, inspect it like an object but add the constructor name

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -26,7 +26,7 @@ describe('objects', () => {
     expect(inspect(obj, { customInspect: false })).to.equal('{ inspect: [Function inspect] }')
   })
   
-  it('uses custom inspect function is `customInspect` is turned on', () => {
+  it('uses custom inspect function if `customInspect` is turned on', () => {
     const obj = {
       'inspect': () => 1
     }

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -16,6 +16,20 @@ describe('objects', () => {
   })
 
   it('correctly inspects properties and Symbols as object keys', () => {
-    expect(inspect({ foo: 1, [Symbol('foo')]: 1 })).to.equal('{ foo: 1, [Symbol(foo)]: 1 }')
+    expect(inspect({foo: 1, [Symbol('foo')]: 1})).to.equal('{ foo: 1, [Symbol(foo)]: 1 }')
+  })
+
+  it('does not use custom inspect functions if `customInspect` is turned off', () => {
+    const obj = {
+      'inspect': () => 1
+    }
+    expect(inspect(obj, { customInspect: false })).to.equal('{ inspect: [Function inspect] }')
+  })
+  
+  it('uses custom inspect function is `customInspect` is turned on', () => {
+    const obj = {
+      'inspect': () => 1
+    }
+    expect(inspect(obj, { customInspect: true })).to.equal(1)
   })
 })

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -16,31 +16,29 @@ describe('objects', () => {
   })
 
   it('correctly inspects properties and Symbols as object keys', () => {
-    expect(inspect({foo: 1, [Symbol('foo')]: 1})).to.equal('{ foo: 1, [Symbol(foo)]: 1 }')
+    expect(inspect({ foo: 1, [Symbol('foo')]: 1 })).to.equal('{ foo: 1, [Symbol(foo)]: 1 }')
   })
 
   it('does not use custom inspect functions if `customInspect` is turned off', () => {
     const obj = {
-      'inspect': () => 1
+      inspect: () => 1,
     }
     expect(inspect(obj, { customInspect: false })).to.equal('{ inspect: [Function inspect] }')
   })
-  
+
   it('uses custom inspect function if `customInspect` is turned on', () => {
     const obj = {
-      'inspect': () => 1
+      inspect: () => 1,
     }
-    expect(inspect(obj, {customInspect: true})).to.equal(1)
+    expect(inspect(obj, { customInspect: true })).to.equal(1)
   })
 
   it('uses a custom deeply nested inspect function if `customInspect` is turned on', () => {
     const obj = {
       sub: {
-        'inspect': (depth, options) => {
-          return options.stylize('Object content', 'string')
-        }
-      }
+        inspect: (depth, options) => options.stylize('Object content', 'string'),
+      },
     }
-    expect(inspect(obj, {customInspect: true})).to.equal('{ sub: Object content }')
+    expect(inspect(obj, { customInspect: true })).to.equal('{ sub: Object content }')
   })
 })

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -30,6 +30,17 @@ describe('objects', () => {
     const obj = {
       'inspect': () => 1
     }
-    expect(inspect(obj, { customInspect: true })).to.equal(1)
+    expect(inspect(obj, {customInspect: true})).to.equal(1)
+  })
+
+  it('uses a custom deeply nested inspect function if `customInspect` is turned on', () => {
+    const obj = {
+      sub: {
+        'inspect': (depth, options) => {
+          return options.stylize('Object content', 'string')
+        }
+      }
+    }
+    expect(inspect(obj, {customInspect: true})).to.equal('{ sub: Object content }')
   })
 })


### PR DESCRIPTION
Mentioned in https://github.com/chaijs/loupe/issues/37#issuecomment-769746796 is that Loupe ignores `customInspect` symbols for "plain" objects. This fixes that.

Fixes https://github.com/chaijs/loupe/issues/37