### PR TITLE
fix(function): use correct `get-func-name` package

### DIFF
--- a/lib/function.js
+++ b/lib/function.js
@@ -1,9 +1,9 @@
-import getFunctionName from 'get-function-name'
+import getFunctionName from 'get-func-name'
 import { truncate } from './helpers'
 
 export default function inspectFunction(func, options) {
   const name = getFunctionName(func)
-  if (name === 'anonymous') {
+  if (!name) {
     return options.stylize('[Function]', 'special')
   }
   return options.stylize(`[Function ${truncate(name, options.truncate - 11)}]`, 'special')

--- a/package-lock.json
+++ b/package-lock.json
@@ -25312,13 +25312,7 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
-      "dev": true
-    },
-    "get-function-name": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/get-function-name/-/get-function-name-0.0.1.tgz",
-      "integrity": "sha1-bWL5dza1BOac+seryF1QILWZjcc="
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE="
     },
     "get-intrinsic": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "bracketSpacing": true
   },
   "dependencies": {
-    "get-function-name": "0.0.1",
+    "get-func-name": "^2.0.0",
     "type-detect": "^4.0.8"
   },
   "devDependencies": {

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -39,16 +39,23 @@ describe('objects', () => {
         inspect: (depth, options) => options.stylize('Object content', 'string'),
       },
     }
-    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: 'Object content' }")
+    expect(inspect(obj, {customInspect: true})).to.equal("{ sub: 'Object content' }")
   })
 
   it('inspect with custom object-returning inspect', () => {
     const obj = {
       sub: {
-        inspect: () => ({ foo: 'bar' }),
+        inspect: () => ({foo: 'bar'}),
       },
     }
 
-    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: { foo: 'bar' } }")
+    expect(inspect(obj, {customInspect: true})).to.equal("{ sub: { foo: 'bar' } }")
+  })
+
+})
+
+describe('arrays', () => {
+  it('can contain anonymous functions', () => {
+    expect(inspect([() => 1])).to.equal('[ [Function] ]')
   })
 })

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -39,19 +39,18 @@ describe('objects', () => {
         inspect: (depth, options) => options.stylize('Object content', 'string'),
       },
     }
-    expect(inspect(obj, {customInspect: true})).to.equal("{ sub: 'Object content' }")
+    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: 'Object content' }")
   })
 
   it('inspect with custom object-returning inspect', () => {
     const obj = {
       sub: {
-        inspect: () => ({foo: 'bar'}),
+        inspect: () => ({ foo: 'bar' }),
       },
     }
 
-    expect(inspect(obj, {customInspect: true})).to.equal("{ sub: { foo: 'bar' } }")
+    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: { foo: 'bar' } }")
   })
-
 })
 
 describe('arrays', () => {


### PR DESCRIPTION
Mistakenly, we added the `get-function-name` package when it should be `get-func-name`. 

This fixes that, and adds a test that breaks with `get-function-name`.

Fixes #42 