### PR TITLE
fix: ensure no warnings when bundled

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ const chaiInspect = symbolsSupported ? Symbol.for('chai/inspect') : '@@chai/insp
 let nodeInspect = false
 try {
   // eslint-disable-next-line global-require
-  nodeInspect = require('util').inspect.custom
+  const nodeUtil = require('util');
+  nodeInspect = nodeUtil.inspect ? nodeUtil.inspect.custom : false;
 } catch (noNodeInspect) {
   nodeInspect = false
 }

--- a/index.js
+++ b/index.js
@@ -29,8 +29,8 @@ const chaiInspect = symbolsSupported ? Symbol.for('chai/inspect') : '@@chai/insp
 let nodeInspect = false
 try {
   // eslint-disable-next-line global-require
-  const nodeUtil = require('util');
-  nodeInspect = nodeUtil.inspect ? nodeUtil.inspect.custom : false;
+  const nodeUtil = require('util')
+  nodeInspect = nodeUtil.inspect ? nodeUtil.inspect.custom : false
 } catch (noNodeInspect) {
   nodeInspect = false
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
   ],
   "main": "./loupe.js",
   "module": "./index.js",
+  "browser": {
+    "util": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/loupe"


### PR DESCRIPTION
node "util" is now mapped to an empty object and checked in runtime.

addresses https://github.com/chaijs/chai/issues/1447