### PR TITLE
Degrade more gracefully on promise inpsection capabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,8 +4,6 @@
  * MIT Licensed
  */
 
-import typeDetect from 'type-detect'
-
 import inspectArray from './lib/array'
 import inspectTypedArray from './lib/typedarray'
 import inspectDate from './lib/date'
@@ -118,12 +116,17 @@ const inspectCustom = (value, options, type) => {
   return ''
 }
 
+const toString = Object.prototype.toString
+
 // eslint-disable-next-line complexity
 export function inspect(value, options) {
   options = normaliseOptions(options)
   options.inspect = inspect
   const { customInspect } = options
-  const type = typeDetect(value)
+  let type = value === null ? 'null' : typeof value
+  if (type === 'object') {
+    type = toString.call(value).slice(8, -1)
+  }
 
   // If it is a base value that we already support, then use Loupe's inspector
   if (baseTypesMap[type]) {

--- a/lib/promise.js
+++ b/lib/promise.js
@@ -1,12 +1,14 @@
 let getPromiseValue = () => 'Promise{…}'
 try {
   const { getPromiseDetails, kPending, kRejected } = process.binding('util')
-  getPromiseValue = (value, options) => {
-    const [state, innerValue] = getPromiseDetails(value)
-    if (state === kPending) {
-      return 'Promise{<pending>}'
+  if (Array.isArray(getPromiseDetails(Promise.resolve()))) {
+    getPromiseValue = (value, options) => {
+      const [state, innerValue] = getPromiseDetails(value)
+      if (state === kPending) {
+        return 'Promise{<pending>}'
+      }
+      return `Promise${state === kRejected ? '!' : ''}{${options.inspect(innerValue, options)}}`
     }
-    return `Promise${state === kRejected ? '!' : ''}{${options.inspect(innerValue, options)}}`
   }
 } catch (notNode) {
   /* ignore */

--- a/package-lock.json
+++ b/package-lock.json
@@ -14082,7 +14082,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",

--- a/package.json
+++ b/package.json
@@ -94,8 +94,7 @@
     "bracketSpacing": true
   },
   "dependencies": {
-    "get-func-name": "^2.0.0",
-    "type-detect": "^4.0.8"
+    "get-func-name": "^2.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -26,6 +26,20 @@ describe('objects', () => {
     expect(inspect(obj, { customInspect: false })).to.equal('{ inspect: [Function inspect] }')
   })
 
+  it('uses custom inspect function is `customInspect` is turned on', () => {
+    const obj = {
+      inspect: () => 1,
+    }
+    expect(inspect(obj, { customInspect: true })).to.equal('1')
+  })
+
+  it('does not use custom inspect functions if `customInspect` is turned off', () => {
+    const obj = {
+      inspect: () => 1,
+    }
+    expect(inspect(obj, { customInspect: false })).to.equal('{ inspect: [Function inspect] }')
+  })
+
   it('uses custom inspect function if `customInspect` is turned on', () => {
     const obj = {
       inspect: () => 'abc',

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,10 +1,11 @@
 import inspect from '../index'
 import { expect } from 'chai'
 const isNode = typeof process === 'object' && process.version
+const canInspectPromises = isNode && 'getPromiseDetails' in process.binding('util')
 describe('promises', () => {
-  describe('browser', () => {
+  describe('default behaviour', () => {
     beforeEach(function () {
-      if (isNode) {
+      if (isNode && canInspectPromises) {
         // eslint-disable-next-line no-invalid-this
         this.skip()
       }
@@ -36,9 +37,9 @@ describe('promises', () => {
     })
   })
 
-  describe('node', () => {
+  describe('node <= 16', () => {
     beforeEach(function () {
-      if (!isNode) {
+      if (!isNode || !canInspectPromises) {
         // eslint-disable-next-line no-invalid-this
         this.skip()
       }


### PR DESCRIPTION
Loupe fails on Node since 16 which dropped `process.binding('util').getPromiseDetail`. See https://github.com/nodejs/node/issues/40054 for more.

This more gracefully degrades when that function is not available.