### PR TITLE
fix: ensure es5 target is bundle-compatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
   ],
   "main": "./loupe.js",
   "module": "./index.js",
-  "browser": "./loupe.js",
+  "browser": {
+    "./index.js": "./loupe.js",
+    "util": false
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/chaijs/loupe"
@@ -37,7 +40,7 @@
   "eslintConfig": {
     "root": true,
     "parserOptions": {
-      "ecmaVersion": "2020"
+      "ecmaVersion": 2020
     },
     "env": {
       "es6": true


### PR DESCRIPTION
when #54 was merged to fix #53, it also regressed the fix in #50 back into showing bundle warnings.

this PR ensures the es5 loupe.js is picked for browsers, while still mapping util to an empty object (for the `require("util")` call).

also did a tiny adjustment (string -> number) to the `eslintConfig` to match its schema.