### PR TITLE
fix: Invalid Date object will throw a TypeError (#58)

### DIFF
--- a/lib/date.js
+++ b/lib/date.js
@@ -2,12 +2,13 @@ import { truncate } from './helpers'
 
 export default function inspectDate(dateObject, options) {
   const stringRepresentation = dateObject.toJSON()
+
   if (stringRepresentation === null) {
     return 'Invalid Date'
-  } else {
-    const split = stringRepresentation.split('T')
-    const date = split[0]
-    // If we need to - truncate the time portion, but never the date
-    return options.stylize(`${date}T${truncate(split[1], options.truncate - date.length - 1)}`, 'date')
   }
+
+  const split = stringRepresentation.split('T')
+  const date = split[0]
+  // If we need to - truncate the time portion, but never the date
+  return options.stylize(`${date}T${truncate(split[1], options.truncate - date.length - 1)}`, 'date')
 }

--- a/lib/date.js
+++ b/lib/date.js
@@ -1,8 +1,13 @@
 import { truncate } from './helpers'
 
 export default function inspectDate(dateObject, options) {
-  // If we need to - truncate the time portion, but never the date
-  const split = dateObject.toJSON().split('T')
-  const date = split[0]
-  return options.stylize(`${date}T${truncate(split[1], options.truncate - date.length - 1)}`, 'date')
+  const stringRepresentation = dateObject.toJSON()
+  if (stringRepresentation === null) {
+    return 'Invalid Date'
+  } else {
+    const split = stringRepresentation.split('T')
+    const date = split[0]
+    // If we need to - truncate the time portion, but never the date
+    return options.stylize(`${date}T${truncate(split[1], options.truncate - date.length - 1)}`, 'date')
+  }
 }

--- a/test/dates.js
+++ b/test/dates.js
@@ -5,6 +5,11 @@ describe('date', () => {
     expect(inspect(new Date(1475318637123))).to.equal('2016-10-01T10:43:57.123Z')
   })
 
+  it('returns "Invalid Date" if given an invalid Date object', () => {
+    // See: https://github.com/chaijs/loupe/issues/58
+    expect(inspect(new Date('not a date'))).to.equal('Invalid Date')
+  })
+
   describe('colors', () => {
     it('returns date with red color, if colour is set to true', () => {
       expect(inspect(new Date(1475318637123), { colors: true })).to.equal(


### PR DESCRIPTION
This PR will make sure that `loupe` will return `"Invalid Date"` if a `Date` object is invalid. It does **not** deal with _how_ the `Date` object became invalid as that depends on JS engine.

See https://github.com/chaijs/loupe/issues/58#issuecomment-1303259185 for a comparison between V8 and Firefox's SpiderMoney.