### PR TITLE
upgrade get-func-name for CVE-2023-43646

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "bracketSpacing": true
   },
   "dependencies": {
-    "get-func-name": "^2.0.0"
+    "get-func-name": "^2.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
`get-func-name` is vulnerable up to (but excluding) `2.0.0` -- change the requirement to `^2.0.1` to shut dependabot up