### PR TITLE
use standardised publish step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,16 +11,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the project
-      uses: actions/checkout@v2
-    - name: Use Node.js 18
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
-    - name: Install dependencies
-      run: npm i
-    - name: Run lint step
-      run: npm run lint
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Use Node.js 18
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - name: Install dependencies
+        run: npm i
+      - name: Run lint step
+        run: npm run lint
 
   test-node:
     name: Test on Node.js
@@ -28,70 +28,50 @@ jobs:
     strategy:
       matrix:
         node-version:
-        - 16.x # to be removed 2023-09-11
-        - 18.x # to be removed 2025-04-30
-        - 20.x # to be removed 2026-04-30
+          - 18.x # to be removed 2025-04-30
+          - 20.x # to be removed 2026-04-30
+          - 21.x # to be removed 2024-06-01
     steps:
-    - name: Checkout the project
-      uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: Install dependencies
-      run: npm i
-    - name: Run Node.js Tests
-      run: npm run test:node
+      - name: Checkout the project
+        uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Install dependencies
+        run: npm i
+      - name: Run Node.js Tests
+        run: npm run test:node
 
   test-linux-browsers:
     name: Test on Linux Firefox & Chrome
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout the project
-      uses: actions/checkout@v2
-    - name: Use Node.js 18
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
-    - name: Install dependencies
-      run: npm i
-    - name: Run Node.js Tests
-      run: npm run test:browser
-    - name: Upload coverage
-      if: success()
-      uses: codecov/codecov-action@v1
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Use Node.js 18
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - name: Install dependencies
+        run: npm i
+      - name: Run Node.js Tests
+        run: npm run test:browser
+      - name: Upload coverage
+        if: success()
+        uses: codecov/codecov-action@v1
 
   test-windows-browsers:
     name: Test on Windows Firefox, Chrome & Edge
     runs-on: windows-latest
     steps:
-    - name: Checkout the project
-      uses: actions/checkout@v2
-    - name: Use Node.js 18
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
-    - name: Install dependencies
-      run: npm i
-    - name: Run Node.js Tests
-      run: npm run test:browser
-
-  release:
-    name: Publish a Release
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    needs: [lint, test-node, test-linux-browsers]
-    steps:
-    - name: Checkout the project
-      uses: actions/checkout@v2
-    - name: Use Node.js 18
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
-    - name: Install dependencies
-      run: npm i
-    - name: Run Semantic Release
-      run: npx semantic-release
-      env:
-       NPM_TOKEN: ${{secrets.NPM_TOKEN}}
-       GITHUB_TOKEN: ${{secrets.github_token}}
+      - name: Checkout the project
+        uses: actions/checkout@v2
+      - name: Use Node.js 18
+        uses: actions/setup-node@v1
+        with:
+          node-version: 18.x
+      - name: Install dependencies
+        run: npm i
+      - name: Run Node.js Tests
+        run: npm run test:browser

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm whoami; npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Node 16 is now EOL so we should only support 18+

This also changes the publish step to be like deep-eql.