### PR TITLE
Add `sourceURL` to list of error keys.

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,7 @@ const errorKeys = [
   'columnNumber',
   'number',
   'description',
+  'sourceURL'
 ]
 
 export default function inspectObject(error: Error, options: Options) {

--- a/src/error.ts
+++ b/src/error.ts
@@ -12,7 +12,7 @@ const errorKeys = [
   'columnNumber',
   'number',
   'description',
-  'sourceURL'
+  'sourceURL' // A property that seems to be only in Safari
 ]
 
 export default function inspectObject(error: Error, options: Options) {


### PR DESCRIPTION
It looks like Safari has some property on errors that I can't find anything about online. Adding it to the list so that tests in `chai/chaijs` pass.

See https://github.com/chaijs/chai/pull/1546 for a PR that's failing on Safari. Direct link to build: https://github.com/chaijs/chai/actions/runs/6610600744/job/17952929090?pr=1546.

Test failures:

```
test/globalErr.js:

 ❌ globalErr > should throw if object val's props are not included in error object
      AssertionError: expected 'expected AssertionError: cat { source…' to match /expected AssertionError: cat to have property \'text\'/
        at AssertionError (chai.js:294:10)
        at chai.js:1545:29
        at assertMatch (chai.js:2645:14)
        at chai.js:1708:30
        at globalErr (test/bootstrap/index.js:49:62)
        at test/globalErr.js:165:8

 ❌ globalErr > skipStackTest > falsey > should throw if "Getter" is in the stack trace
      AssertionError: Expected an error
        at AssertionError (chai.js:294:10)
        at globalErr (test/bootstrap/index.js:58:32)
        at test/globalErr.js:241:12

 ❌ globalErr > skipStackTest > falsey > should throw if "Wrapper" is in the stack trace
      AssertionError: Expected an error
        at AssertionError (chai.js:294:10)
        at globalErr (test/bootstrap/index.js:58:32)
        at test/globalErr.js:249:12

 ❌ globalErr > skipStackTest > falsey > should throw if "assert" is in the stack trace
      AssertionError: Expected an error
        at AssertionError (chai.js:294:10)
        at globalErr (test/bootstrap/index.js:58:32)
        at test/globalErr.js:257:12

```
