### PR TITLE
Add support for different types of functions

### DIFF
--- a/src/function.ts
+++ b/src/function.ts
@@ -1,13 +1,10 @@
 import { truncate } from './helpers.js'
 import type { Options } from './types.js'
 
-export default function inspectFunction(func: Function, options: Options) {
-  let functionType = 'Function'
-  // @ts-ignore
-  const stringTag = func[Symbol.toStringTag];
-  if (typeof stringTag === 'string') {
-    functionType = stringTag;
-  }
+type ToStringable = Function & {[Symbol.toStringTag]: string};
+
+export default function inspectFunction(func: ToStringable, options: Options) {
+  const functionType = func[Symbol.toStringTag] || 'Function'
 
   const name = func.name
   if (!name) {

--- a/src/function.ts
+++ b/src/function.ts
@@ -2,9 +2,16 @@ import { truncate } from './helpers.js'
 import type { Options } from './types.js'
 
 export default function inspectFunction(func: Function, options: Options) {
+  let functionType = 'Function'
+  // @ts-ignore
+  const stringTag = func[Symbol.toStringTag];
+  if (typeof stringTag === 'string') {
+    functionType = stringTag;
+  }
+
   const name = func.name
   if (!name) {
-    return options.stylize('[Function]', 'special')
+    return options.stylize(`[${functionType}]`, 'special')
   }
-  return options.stylize(`[Function ${truncate(name, options.truncate - 11)}]`, 'special')
+  return options.stylize(`[${functionType} ${truncate(name, options.truncate - 11)}]`, 'special')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export function inspect(value: unknown, opts: Partial<Options> = {}): string {
   if (type === 'object') {
     type = toString.call(value).slice(8, -1)
   }
-
+  
   // If it is a base value that we already support, then use Loupe's inspector
   if (type in baseTypesMap) {
     return (baseTypesMap[type as keyof typeof baseTypesMap] as Inspect)(value, options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ export function inspect(value: unknown, opts: Partial<Options> = {}): string {
   if (type === 'object') {
     type = toString.call(value).slice(8, -1)
   }
-  
+
   // If it is a base value that we already support, then use Loupe's inspector
   if (type in baseTypesMap) {
     return (baseTypesMap[type as keyof typeof baseTypesMap] as Inspect)(value, options)

--- a/test/functions.js
+++ b/test/functions.js
@@ -65,3 +65,33 @@ describe('functions', () => {
     })
   })
 })
+
+describe('async functions', () => {
+  it('returns the functions name wrapped in `[AsyncFunction ]`', () => {
+    expect(inspect(async function foo() {})).to.equal('[AsyncFunction foo]')
+  })
+
+  it('returns the `[AsyncFunction]` if given anonymous function', () => {
+    expect(inspect(async function () {})).to.equal('[AsyncFunction]')
+  })
+})
+
+describe('generator functions', () => {
+  it('returns the functions name wrapped in `[GeneratorFunction ]`', () => {
+    expect(inspect(function* foo() {})).to.equal('[GeneratorFunction foo]')
+  })
+
+  it('returns the `[GeneratorFunction]` if given a generator function', () => {
+    expect(inspect(function* () {})).to.equal('[GeneratorFunction]')
+  })
+})
+
+describe('async generator functions', () => {
+  it('returns the functions name wrapped in `[AsyncGeneratorFunction ]`', () => {
+    expect(inspect(async function* foo() {})).to.equal('[AsyncGeneratorFunction foo]')
+  })
+
+  it('returns the `[AsyncGeneratorFunction]` if given a async generator function', () => {
+    expect(inspect(async function* () {})).to.equal('[AsyncGeneratorFunction]')
+  })
+})


### PR DESCRIPTION
`loupe` currently doesn't differentiate between the different functions and it probably should.

See https://github.com/chaijs/chai/pull/1566 