### PR TITLE
chore: remove unused get-func-name dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "loupe",
       "version": "0.0.0-development",
       "license": "MIT",
-      "dependencies": {
-        "get-func-name": "^2.0.1"
-      },
       "devDependencies": {
         "@web/dev-server-esbuild": "^0.4.2",
         "@web/test-runner": "^0.17.2",
@@ -5542,6 +5539,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
       "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -98,9 +98,6 @@
     "arrowParens": "avoid",
     "bracketSpacing": true
   },
-  "dependencies": {
-    "get-func-name": "^2.0.1"
-  },
   "devDependencies": {
     "@web/dev-server-esbuild": "^0.4.2",
     "@web/test-runner": "^0.17.2",


### PR DESCRIPTION
It looks like since https://github.com/chaijs/loupe/pull/62, `get-func-name` is no longer used, so we can remove it from the dependencies.

NOTE: this doesn't affect `chai` for now since it's using loupe v2.