### PR TITLE
fix: handle circular refs in errors

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -12,6 +12,7 @@ const errorKeys = [
   'columnNumber',
   'number',
   'description',
+  'cause',
 ]
 
 export default function inspectObject(error: Error, options: Options) {
@@ -26,6 +27,11 @@ export default function inspectObject(error: Error, options: Options) {
   }
   message = message ? `: ${message}` : ''
   options.truncate -= message.length + 5
+  options.seen = options.seen || []
+  if (options.seen.indexOf(error) >= 0) {
+    return '[Circular]'
+  }
+  options.seen.push(error)
   const propertyContents = inspectList(
     properties.map(key => [key, error[key as keyof typeof error]]),
     options,

--- a/src/error.ts
+++ b/src/error.ts
@@ -28,7 +28,7 @@ export default function inspectObject(error: Error, options: Options) {
   message = message ? `: ${message}` : ''
   options.truncate -= message.length + 5
   options.seen = options.seen || []
-  if (options.seen.indexOf(error) >= 0) {
+  if (options.seen.includes(error)) {
     return '[Circular]'
   }
   options.seen.push(error)

--- a/src/object.ts
+++ b/src/object.ts
@@ -9,7 +9,7 @@ export default function inspectObject(object: object, options: Options): string 
   }
   options.truncate -= 4
   options.seen = options.seen || []
-  if (options.seen.indexOf(object) >= 0) {
+  if (options.seen.includes(object)) {
     return '[Circular]'
   }
   options.seen.push(object)

--- a/test/errors.js
+++ b/test/errors.js
@@ -33,5 +33,19 @@ describe('errors', () => {
       err.message = { code: 404 }
       expect(inspect(err)).to.equal('Error { message: { code: 404 } }')
     })
+
+    it('detects circular references', () => {
+      const err = new Error('message')
+      err.fluff = err
+      expect(inspect(err)).to.equal('Error: message { fluff: [Circular] }')
+    })
+  })
+
+  describe('ignores built in properties', () => {
+    it('does not add property to output', () => {
+      const err = new Error('message')
+      err.cause = new Error('i caused you')
+      expect(inspect(err)).to.equal('Error: message')
+    })
   })
 })


### PR DESCRIPTION
Fixes chaijs/chai#1645

We already handle circular references in objects, but do not do the same for `Error` objects. This change adds the same `seen` logic to error inspection as we have in object inspection.

Also adds `cause` to the list of "built in" properties