### PR TITLE
chore: enable `skipLibCheck`

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,7 @@
     "strict": true,
     "declaration": true,
     "declarationMap": true,
-    "moduleResolution": "bundler"
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Some dependencies ship types which fail with our strictness level. This should skip them so our builds continue to work.