### PR TITLE
fix: do not treat a NodeList as HTMLCollection

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -9,10 +9,19 @@ export function inspectAttribute([key, value]: [unknown, unknown], options: Opti
   return `${options.stylize(String(key), 'yellow')}=${options.stylize(`"${value}"`, 'string')}`
 }
 
-// @ts-ignore (Deno doesn't have Element)
-export function inspectHTMLCollection(collection: ArrayLike<Element>, options: Options): string {
-  // eslint-disable-next-line no-use-before-define
-  return inspectList(collection, options, inspectHTML as Inspect, '\n')
+export function inspectNodeCollection(collection: ArrayLike<Node>, options: Options): string {
+  return inspectList(collection, options, inspectNode as Inspect, '\n')
+}
+
+export function inspectNode(node: Node, options: Options): string {
+  switch (node.nodeType) {
+    case 1:
+      return inspectHTML(node as Element, options)
+    case 3:
+      return options.inspect((node as Text).data, options)
+    default:
+      return options.inspect(node, options)
+  }
 }
 
 // @ts-ignore (Deno doesn't have Element)
@@ -35,7 +44,7 @@ export default function inspectHTML(element: Element, options: Options): string 
   }
   options.truncate -= propertyContents.length
   const truncate = options.truncate
-  let children = inspectHTMLCollection(element.children, options)
+  let children = inspectNodeCollection(element.children, options)
   if (children && children.length > truncate) {
     children = `${truncator}(${element.children.length})`
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ const baseTypesMap = {
   Error: inspectError,
 
   HTMLCollection: inspectHTMLCollection,
-  NodeList: inspectHTMLCollection,
+  NodeList: inspectArray,
 } as const
 
 // eslint-disable-next-line complexity

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import inspectClass from './class.js'
 import inspectObject from './object.js'
 import inspectArguments from './arguments.js'
 import inspectError from './error.js'
-import inspectHTMLElement, { inspectHTMLCollection } from './html.js'
+import inspectHTMLElement, { inspectNodeCollection } from './html.js'
 
 import { normaliseOptions } from './helpers.js'
 import type { Inspect, Options } from './types.js'
@@ -90,8 +90,8 @@ const baseTypesMap = {
 
   Error: inspectError,
 
-  HTMLCollection: inspectHTMLCollection,
-  NodeList: inspectArray,
+  HTMLCollection: inspectNodeCollection,
+  NodeList: inspectNodeCollection,
 } as const
 
 // eslint-disable-next-line complexity


### PR DESCRIPTION
An `HTMLCollection` assumes all items are `Element`s, a `NodeList` however may also include `Node`s such as `Text` and `Comment`, which does not include the `getAttributeNames` method.

Stops the error described here https://github.com/chaijs/chai/issues/1680 but logging that div from inside the iframe changes the output a bit, logging it as a regular object ( `HTMLDivElement{ …(1) }` ), but in a way that is still acceptable to me for now, until we wait for the proper fix described here: https://github.com/chaijs/chai/issues/1680#issuecomment-2717939982

