### PR TITLE
feat: simplify promise inspection

### DIFF
--- a/src/promise.ts
+++ b/src/promise.ts
@@ -1,19 +1,4 @@
 import type { Options } from './types.js'
 type GetPromiseValue = (value: Promise<unknown>, options: Options) => string
-let getPromiseValue: GetPromiseValue = () => 'Promise{…}'
-try {
-  // @ts-ignore
-  const { getPromiseDetails, kPending, kRejected } = process.binding('util')
-  if (Array.isArray(getPromiseDetails(Promise.resolve()))) {
-    getPromiseValue = (value, options: Options) => {
-      const [state, innerValue] = getPromiseDetails(value)
-      if (state === kPending) {
-        return 'Promise{<pending>}'
-      }
-      return `Promise${state === kRejected ? '!' : ''}{${options.inspect(innerValue, options)}}`
-    }
-  }
-} catch (notNode) {
-  /* ignore */
-}
+const getPromiseValue: GetPromiseValue = () => 'Promise{…}'
 export default getPromiseValue

--- a/test/promises.js
+++ b/test/promises.js
@@ -1,15 +1,7 @@
 import inspect from '../lib/index.js'
 import { expect } from 'chai'
-const isNode = typeof process === 'object' && process.version
-const canInspectPromises = isNode && 'getPromiseDetails' in process.binding('util')
 describe('promises', () => {
   describe('default behaviour', () => {
-    beforeEach(function () {
-      if (isNode && canInspectPromises) {
-        this.skip()
-      }
-    })
-
     it('returns `Promise{…}` for a Promise', () => {
       expect(inspect(Promise.resolve())).to.equal('Promise{…}')
     })
@@ -19,6 +11,18 @@ describe('promises', () => {
       expect(inspect(prom)).to.equal('Promise{…}')
       // catch the promise to prevent warnings
       prom.catch(() => {})
+    })
+
+    it('returns `Promise{…}` for a pending Promise', () => {
+      let resolver
+      try {
+        const prom = new Promise(resolve => {
+          resolver = resolve
+        })
+        expect(inspect(prom)).to.equal('Promise{…}')
+      } finally {
+        resolver()
+      }
     })
 
     describe('truncate', () => {
@@ -33,29 +37,6 @@ describe('promises', () => {
         expect(inspect(Promise.resolve(), { truncate: 2 })).to.equal('Promise{…}')
         expect(inspect(Promise.resolve(), { truncate: 1 })).to.equal('Promise{…}')
       })
-    })
-  })
-
-  describe('node <= 16', () => {
-    beforeEach(function () {
-      if (!isNode || !canInspectPromises) {
-        this.skip()
-      }
-    })
-
-    it('returns an inspected version of the Promise value if it has already resolved', () => {
-      expect(inspect(Promise.resolve(4))).to.equal('Promise{4}')
-    })
-
-    it('returns a "pending" version of the Promise value if it is pending', () => {
-      expect(inspect(new Promise(() => {}))).to.equal('Promise{<pending>}')
-    })
-
-    it('returns a "rejected" version of the Promise value if it is rejected', () => {
-      const prom = Promise.reject(new Error('Foo'))
-      expect(inspect(prom)).to.equal('Promise!{Error: Foo}')
-      // catch the promise to prevent warnings
-      return prom.catch(() => {})
     })
   })
 })


### PR DESCRIPTION
Dumbs it down to always return `Promise{...}` regardless of the state
and platform/engine we're in, since Node has deprecated the private API
we were using.

Fixes #108 