### PR TITLE
Fix: inject inspect fn so it behaves like NodeJS inspect

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,13 +87,13 @@ const baseTypesMap = {
 } as const
 
 // eslint-disable-next-line complexity
-const inspectCustom = (value: object, options: Options, type: string): string => {
+const inspectCustom = (value: object, options: Options, type: string, inspectFn: typeof inspect): string => {
   if (chaiInspect in value && typeof (value as any)[chaiInspect] === 'function') {
     return ((value as any)[chaiInspect] as Function)(options)
   }
 
   if (nodeInspect in value && typeof (value as any)[nodeInspect] === 'function') {
-    return ((value as any)[nodeInspect] as Function)(options.depth, options)
+    return ((value as any)[nodeInspect] as Function)(options.depth, options, inspectFn)
   }
 
   if ('inspect' in value && typeof value.inspect === 'function') {
@@ -129,7 +129,7 @@ export function inspect(value: unknown, opts: Partial<Options> = {}): string {
 
   // If `options.customInspect` is set to true then try to use the custom inspector
   if (customInspect && value) {
-    const output = inspectCustom(value, options, type)
+    const output = inspectCustom(value, options, type, inspect)
     if (output) {
       if (typeof output === 'string') return output
       return inspect(output, options)

--- a/test/acceptance.js
+++ b/test/acceptance.js
@@ -76,11 +76,12 @@ describe('objects', () => {
   it('inspect with node-style custom inspect', () => {
     const obj = {
       sub: {
-        [Symbol.for('nodejs.util.inspect.custom')]: () => ({ foo: 'bar' }),
+        [Symbol.for('nodejs.util.inspect.custom')]: (depth, options, inspect) =>
+          `Foo { depth=${depth}, foo=${inspect(['bar', 1])} } }`,
       },
     }
 
-    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: { foo: 'bar' } }")
+    expect(inspect(obj, { customInspect: true })).to.equal("{ sub: Foo { depth=2, foo=[ 'bar', 1 ] } } }")
   })
 })
 


### PR DESCRIPTION
This pull request injects the inject function as a third parameter so it behaves just like native nodejs inspect function